### PR TITLE
Fix prodcons logs

### DIFF
--- a/produttore_consumatore/prodcons_coda_circolare.c
+++ b/produttore_consumatore/prodcons_coda_circolare.c
@@ -67,7 +67,7 @@ void produttore(struct prodcons * p, int ds_sem) {
 	// genera valore tra 0 e 99
 	p->buffer[p->testa] = rand() % 100;
 
-	printf("Il valore prodotto = %d\n", p->buffer[p->testa]);
+	printf("[PROD %d] Il valore prodotto = %d\n", getpid(), p->buffer[p->testa]);
 
 	p->testa = (p->testa+1) % DIM_BUFFER;
 
@@ -88,7 +88,7 @@ void consumatore(struct prodcons * p, int ds_sem) {
 
 	sleep(2);
 
-	printf("Il valore consumato = %d\n", p->buffer[p->coda]);
+	printf("[CONS %d] Il valore consumato = %d\n", getpid(), p->buffer[p->coda]);
 
 	p->coda = (p->coda + 1) % DIM_BUFFER;
 
@@ -131,7 +131,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_CONSUMATORI; i++) {
+	for(int i=0; i<NUM_CONSUMATORI; ++i) {
 
 		int pid = fork();
 
@@ -148,6 +148,7 @@ int main() {
 
 			consumatore(p, ds_sem);
 
+			printf("Figlio consumatore terminato: %d\n", getpid());
 			exit(1);
 		}
 	}
@@ -155,7 +156,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_PRODUTTORI; i++) {
+	for(int i=0; i<NUM_PRODUTTORI; ++i) {
 
 		int pid = fork();
 
@@ -171,21 +172,16 @@ int main() {
 			srand(getpid()*time(NULL));
 
 			produttore(p, ds_sem);
-
+			
+			printf("Figlio produttore terminato: %d\n", getpid());
 			exit(1);
 		}
 	}
 
 
 
-	for(int i=0; i<NUM_PRODUTTORI; i++) {
+	for(int i=0; i< (NUM_PRODUTTORI + NUM_CONSUMATORI); ++i) {
 		wait(NULL);
-		printf("Figlio produttore terminato\n");
-	}
-
-	for(int i=0; i<NUM_CONSUMATORI; i++) {
-		wait(NULL);
-		printf("Figlio consumatore terminato\n");
 	}
 
 

--- a/produttore_consumatore/prodcons_coda_circolare.c
+++ b/produttore_consumatore/prodcons_coda_circolare.c
@@ -105,7 +105,10 @@ int main() {
 
 	int ds_shm = shmget(chiave, sizeof(struct prodcons), IPC_CREAT|0664);
 
-	if(ds_shm<0) { perror("SHM errore"); exit(1); }
+	if(ds_shm<0) {
+		perror("SHM errore");
+		exit(1);
+	}
 
 	struct prodcons * p;
 
@@ -120,7 +123,10 @@ int main() {
 
 	int ds_sem = semget(chiavesem, 4, IPC_CREAT|0664);
 
-	if(ds_sem<0) { perror("SEM errore"); exit(1); }
+	if(ds_sem<0) {
+		perror("SEM errore");
+		exit(1);
+	}
 
 	
 
@@ -131,7 +137,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_CONSUMATORI; ++i) {
+	for(int i=0; i<NUM_CONSUMATORI; i++) {
 
 		int pid = fork();
 
@@ -156,7 +162,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_PRODUTTORI; ++i) {
+	for(int i=0; i<NUM_PRODUTTORI; i++) {
 
 		int pid = fork();
 
@@ -180,7 +186,7 @@ int main() {
 
 
 
-	for(int i=0; i< (NUM_PRODUTTORI + NUM_CONSUMATORI); ++i) {
+	for(int i=0; i<(NUM_PRODUTTORI + NUM_CONSUMATORI); i++) {
 		wait(NULL);
 	}
 

--- a/produttore_consumatore/prodcons_pool_buffer.c
+++ b/produttore_consumatore/prodcons_pool_buffer.c
@@ -79,7 +79,7 @@ void produttore(struct prodcons * p, int ds_sem) {
 	// genera valore tra 0 e 99
 	p->buffer[indice] = rand() % 100;
 
-	printf("Il valore prodotto = %d\n", p->buffer[indice]);
+	printf("[PROD %d] Il valore prodotto = %d\n", getpid(), p->buffer[indice]);
 
 
 	p->stato[indice] = BUFFER_PIENO;
@@ -108,7 +108,7 @@ void consumatore(struct prodcons * p, int ds_sem) {
 
 	sleep(2);
 
-	printf("Il valore consumato = %d\n", p->buffer[indice]);
+	printf("[CONS %d] Il valore consumato = %d\n", getpid(), p->buffer[indice]);
 
 
 	p->stato[indice] = BUFFER_VUOTO;
@@ -130,7 +130,7 @@ int main() {
 	p = (struct prodcons *) shmat(ds_shm, NULL, 0);
 
 
-	for(int i=0; i<DIM_BUFFER; i++) {
+	for(int i=0; i<DIM_BUFFER; ++i) {
 		p->stato[i] = BUFFER_VUOTO;
 	}
 
@@ -151,7 +151,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_CONSUMATORI; i++) {
+	for(int i=0; i<NUM_CONSUMATORI; ++i) {
 
 		int pid = fork();
 
@@ -168,6 +168,7 @@ int main() {
 
 			consumatore(p, ds_sem);
 
+			printf("Figlio consumatore terminato: %d\n", getpid());
 			exit(1);
 		}
 	}
@@ -175,7 +176,7 @@ int main() {
 
 
 
-	for(int i=0; i<NUM_PRODUTTORI; i++) {
+	for(int i=0; i<NUM_PRODUTTORI; ++i) {
 
 		int pid = fork();
 
@@ -192,20 +193,15 @@ int main() {
 
 			produttore(p, ds_sem);
 
+			printf("Figlio produttore terminato: %d\n", getpid());
 			exit(1);
 		}
 	}
 
 
 
-	for(int i=0; i<NUM_PRODUTTORI; i++) {
+	for(int i=0; i< ( NUM_PRODUTTORI + NUM_CONSUMATORI ); ++i) {
 		wait(NULL);
-		printf("Figlio produttore terminato\n");
-	}
-
-	for(int i=0; i<NUM_CONSUMATORI; i++) {
-		wait(NULL);
-		printf("Figlio consumatore terminato\n");
 	}
 
 


### PR DESCRIPTION
Buonasera professore,

sono uno studente del corso di sistemi operativi a San Giovanni,

ho notato che i log sul termine dei processi figli, nelle applicazioni produttore-consumatore con la circular queue e il pool buffer sono scorretti in quanto non considerano il caso in cui un consumer venga chiuso prima di un producer, es:

![image](https://github.com/rnatella/so_esempi/assets/62134093/de243e81-8371-463d-96f3-aa7777d0bdf6)

per questo ho provato a risolvere questo problema con la soluzione che ho usato nel mio programma con la queue,
inserendo il print della chiusura all'interno del codice del figlio
(inoltre ho aggiunto il PID nei log per facilitare il controllo)

![image](https://github.com/rnatella/so_esempi/assets/62134093/31dc911b-91fe-4f53-aa55-5e38145bfa76)

(Ho creato direttamente una pull request in modo da non doverla disturbare a lezione)